### PR TITLE
ActiveAdmin uses Pluralized file names

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -171,7 +171,7 @@ module AnnotateModels
       when 'controller'
         [File.join(root_directory, CONTROLLER_DIR, "%PLURALIZED_MODEL_NAME%_controller.rb")]
       when 'admin'
-        [File.join(root_directory, ACTIVEADMIN_DIR, "%MODEL_NAME%.rb")]
+        [File.join(root_directory, ACTIVEADMIN_DIR, "%PLURALIZED_MODEL_NAME%.rb")]
       when 'helper'
         [File.join(root_directory, HELPER_DIR, "%PLURALIZED_MODEL_NAME%_helper.rb")]
       else


### PR DESCRIPTION
Changing ActiveAdmin code so it reads pluralized model named files.  This is how active admin generates the files when using its own generator, so I think this gem ought to follow what the gem produces in its own generator.

Ex:

`rails g active_admin:resource Foo` will create a file with a pluralized file name `app/admin/foos.rb`.
